### PR TITLE
Release/2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 *.pyc
 .ipynb_checkpoints
 .vscode
+*.itx

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Python 3 (tested with 3.6 - 3.9) environment is required with the following libr
 * Atomistic simulation environment: `ase` (3.18.1)
 * Python Tight Binding: `pythtb` (1.7.2)
 
+Note: the dependencies will be automatically installed via `pip`.
+
 ### Installation
 
 Option 1) Install the library and dependencies hosted on PyPI:

--- a/example.ipynb
+++ b/example.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mfh_model.run_mfh(u = 3.0, print_iter=False, plot=False)"
+    "mfh_model.run_mfh(u = 3.0, print_iter=False, plot=True)"
    ]
   },
   {
@@ -69,7 +69,7 @@
    },
    "outputs": [],
    "source": [
-    "mfh_model.report(num_orb=2, sts_h=10.0, sts_broad=0.05)"
+    "mfh_model.pp.report(num_orb=2, sts_h=8.0, sts_broad=0.05)"
    ]
   },
   {
@@ -81,13 +81,36 @@
     "# Visualize one specific orbital\n",
     "\n",
     "spin = 0\n",
-    "index = 0\n",
+    "index = 12\n",
     "print(\"Orbital index: %d, spin %d\" % (index, spin))\n",
     "print(\"Energy: %.6f eV\" % mfh_model.evals[spin][index])\n",
-    "mfh_model.plot_mo_eigenvector(mo_index=index, spin=spin)\n",
     "\n",
-    "# corresponding eigenvector (each element corresponds in order to atoms defined in geom/mfh_model.ase_geom)\n",
-    "evec = mfh_model.evecs[spin][index]"
+    "# corresponding eigenvector\n",
+    "evec = mfh_model.evecs[spin][index]\n",
+    "\n",
+    "# Visualize eigenvector\n",
+    "mfh_model.pp.plot_mo_eigenvector(mo_index=index, spin=spin)\n",
+    "\n",
+    "# Visualize the orbital squared\n",
+    "mfh_model.pp.plot_orb_squared_map(plt.gca(), evec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Export a map in .itx format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sts_map, extent = mfh_model.pp.calc_sts_map(energy=1.42, broadening=0.1, h=5.0)\n",
+    "\n",
+    "tbmfh.create_itx(data=sts_map, extent=extent, wavename=\"sts_map\", filename=\"example.itx\")"
    ]
   },
   {
@@ -172,7 +195,7 @@
     "# \"open shell\" case, normal MFH\n",
     "mfh_model = tbmfh.MeanFieldHubbardModel(geom, [2.7, 0.1, 0.4], charge=0, multiplicity=1)\n",
     "mfh_model.run_mfh(u = 3.0, print_iter=False, plot=False)\n",
-    "mfh_model.calculate_natural_orbitals()\n",
+    "mfh_model.pp.calculate_natural_orbitals()\n",
     "\n",
     "# \"closed shell\" case (just tight-binding)\n",
     "tb_model = tbmfh.MeanFieldHubbardModel(geom, [2.7, 0.1, 0.4], charge=0, multiplicity=1)\n",
@@ -193,15 +216,15 @@
     "    \n",
     "    fig, axs = plt.subplots(nrows=1, ncols=7, figsize=(7 * mfh_model.figure_size[0], mfh_model.figure_size[1]))\n",
     "    \n",
-    "    mfh_model.plot_no_eigenvector(i_mo, ax=axs[0])\n",
-    "    mfh_model.plot_orb_squared_map(axs[1], mfh_model.no_evecs[i_mo], h=h)\n",
+    "    mfh_model.pp.plot_no_eigenvector(i_mo, ax=axs[0])\n",
+    "    mfh_model.pp.plot_orb_squared_map(axs[1], mfh_model.pp.no_evecs[i_mo], h=h)\n",
     "    \n",
-    "    mfh_model.plot_mo_eigenvector(i_mo, spin=0, ax=axs[2])\n",
-    "    mfh_model.plot_mo_eigenvector(i_mo, spin=1, ax=axs[3])\n",
-    "    mfh_model.plot_sts_map(axs[4], mfh_model.evals[0, i_mo], h=h)\n",
+    "    mfh_model.pp.plot_mo_eigenvector(i_mo, spin=0, ax=axs[2])\n",
+    "    mfh_model.pp.plot_mo_eigenvector(i_mo, spin=1, ax=axs[3])\n",
+    "    mfh_model.pp.plot_sts_map(axs[4], mfh_model.evals[0, i_mo], h=h)\n",
     "    \n",
-    "    tb_model.plot_mo_eigenvector(i_mo, spin=0, ax=axs[5])\n",
-    "    tb_model.plot_sts_map(axs[6], tb_model.evals[0, i_mo], h=h)\n",
+    "    tb_model.pp.plot_mo_eigenvector(i_mo, spin=0, ax=axs[5])\n",
+    "    tb_model.pp.plot_sts_map(axs[6], tb_model.evals[0, i_mo], h=h)\n",
     "    \n",
     "    plt.subplots_adjust(wspace=0.0, hspace=0)\n",
     "    plt.show()"
@@ -231,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tb-mean-field-hubbard",
-    version="1.5.1",
+    version="2.0.0",
     author="Kristjan Eimre",
     author_email="kristjaneimre@gmail.com",
     description="Package to run tight-binding mean field hubbard calculations",

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setuptools.setup(
         "matplotlib",
         "ase",
         "pythtb",
+        'igor-tools @ git+https://git@github.com/nanotech-empa/igor-tools@main#egg=igor-tools',
     ],
 )

--- a/tb_mean_field_hubbard/__init__.py
+++ b/tb_mean_field_hubbard/__init__.py
@@ -1,3 +1,4 @@
 from .mfh import MeanFieldHubbardModel
+from .utils import create_itx
 
 __version__ = "1.5.1"

--- a/tb_mean_field_hubbard/__init__.py
+++ b/tb_mean_field_hubbard/__init__.py
@@ -1,4 +1,4 @@
 from .mfh import MeanFieldHubbardModel
 from .utils import create_itx
 
-__version__ = "1.5.1"
+__version__ = "2.0.0"

--- a/tb_mean_field_hubbard/mfh.py
+++ b/tb_mean_field_hubbard/mfh.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
 
 import ase
 import ase.neighborlist
@@ -9,6 +8,7 @@ import ase.neighborlist
 import pythtb
 
 from . import utils
+from . import mfh_pp
 
 ### ------------------------------------------------------------------------------
 ### Main class
@@ -16,6 +16,9 @@ from . import utils
 
 
 class MeanFieldHubbardModel:
+    """
+    Class that takes care of running the Mean Field Hubbard calculation
+    """
     def __init__(self, ase_geom, t_list=[2.7], charge=0, multiplicity='auto', bond_cutoff='auto'):
 
         self.t_list = t_list
@@ -48,15 +51,24 @@ class MeanFieldHubbardModel:
         self.num_spin_el = None
         self._set_up_tb_model()
 
+        # OUTPUT VARIABLES:
+
+        self.spin_resolved_dens = None
         self.absmag_iter = None
         self.energy_iter = None
 
         self.evals = None
         self.evecs = None
 
-        # natural orbital evals and evecs
-        self.no_evals = None
-        self.no_evecs = None
+        self.const_mfh_energy_term = None
+        self.energy = None
+        self.abs_mag = None
+
+        self.spin_density = None
+        self.gap_a, self.gap_b, self.gap_eff = None, None, None
+
+        # POST-PROCESSING INSTANCE
+        self.pp = mfh_pp.MFHPostProcess(self)
 
     ### ------------------------------------------------------------------------------
     ### TB routines
@@ -260,8 +272,6 @@ class MeanFieldHubbardModel:
         if self.relax_multiplicity:
             self.multiplicity = max(self.num_spin_el) - min(self.num_spin_el) + 1
 
-        # post-process
-
         # constant energy term in the MFH  [ U*sum(<n_i><n_j>) ]
         self.const_mfh_energy_term = -u * np.sum(self.spin_resolved_dens[:, 0] * self.spin_resolved_dens[:, 1])
 
@@ -284,10 +294,6 @@ class MeanFieldHubbardModel:
             ax2.tick_params(axis='y', labelcolor='red')
             plt.show()
 
-    ### -------------------------------------------------------------------
-    ### Postprocess
-    ### -------------------------------------------------------------------
-
     def gaps(self, evals):
         try:
             homo_a = evals[0][self.num_spin_el[0] - 1]
@@ -304,188 +310,3 @@ class MeanFieldHubbardModel:
 
         except IndexError:
             return np.nan, np.nan, np.nan
-
-    def plot_evals(self, evals, filename=None):
-        plt.figure(figsize=(3.0, 6))
-        ax = plt.gca()
-
-        for i_spin in range(2):
-            for i_ev, ev in enumerate(evals[i_spin]):
-                col = 'blue'
-                if i_ev < self.num_spin_el[i_spin]:
-                    col = 'red'
-                line_pos = [0.1, 0.9] if i_spin == 0 else [1.1, 1.9]
-                plt.plot(line_pos, [ev, ev], '-', color=col, lw=2.0, solid_capstyle='round')
-
-        blue_patch = mpatches.Patch(color='blue', label='empty')
-        red_patch = mpatches.Patch(color='red', label='occupied')
-        plt.legend(handles=[blue_patch, red_patch], loc='upper left', bbox_to_anchor=(1.0, 1.0))
-
-        #ax.get_xaxis().set_visible(False)
-        ax.spines['right'].set_visible(False)
-        ax.spines['top'].set_visible(False)
-        #ax.spines['bottom'].set_visible(False)
-        plt.xlim(0.0, 2.0)
-        plt.xticks([0.5, 1.5], ["spin α", "spin β"])
-        #plt.ylim(-6.0, 10.0)
-        plt.ylabel("Energy (eV)")
-        #plt.yticks(fontsize=30)
-        if filename is not None:
-            plt.savefig(filename, dpi=300, bbox_inches='tight')
-        plt.show()
-
-    def _get_atoms_extent(self, atoms, edge_space):
-        xmin = np.min(atoms.positions[:, 0]) - edge_space
-        xmax = np.max(atoms.positions[:, 0]) + edge_space
-        ymin = np.min(atoms.positions[:, 1]) - edge_space
-        ymax = np.max(atoms.positions[:, 1]) + edge_space
-        return xmin, xmax, ymin, ymax
-
-    def calc_orb_map(self, evec, h=10.0, edge_space=5.0, dx=0.1, z_eff=3.25):
-
-        extent = self._get_atoms_extent(self.ase_geom, edge_space)
-
-        # define grid
-        x_arr = np.arange(extent[0], extent[1], dx)
-        y_arr = np.arange(extent[2], extent[3], dx)
-
-        orb_map = np.zeros((len(x_arr), len(y_arr)), dtype=np.complex)
-
-        for at, coef in zip(self.ase_geom, evec):
-            p = at.position
-            local_i, local_grid = utils.get_local_grid(x_arr, y_arr, p, cutoff=1.2 * h + 4.0)
-            pz_orb = utils.carbon_2pz_slater(local_grid[0] - p[0], local_grid[1] - p[1], h, z_eff)
-            orb_map[local_i[0]:local_i[1], local_i[2]:local_i[3]] += coef * pz_orb
-
-        return orb_map
-
-    def plot_orb_squared_map(self, ax, evec, h=10.0, edge_space=5.0, dx=0.1, title=None, cmap='seismic', z_eff=3.25):
-        orb_map = np.abs(self.calc_orb_map(evec, h, edge_space, dx, z_eff))**2
-        extent = self._get_atoms_extent(self.ase_geom, edge_space)
-        ax.imshow(orb_map.T, origin='lower', cmap=cmap, extent=extent)
-        ax.axis('off')
-        ax.set_title(title)
-
-    def calc_sts_map(self, energy, broadening=0.05, h=10.0, edge_space=5.0, dx=0.1, z_eff=3.25):
-
-        extent = self._get_atoms_extent(self.ase_geom, edge_space)
-        # define grid
-        x_arr = np.arange(extent[0], extent[1], dx)
-        y_arr = np.arange(extent[2], extent[3], dx)
-
-        final_map = np.zeros((len(x_arr), len(y_arr)))
-
-        for i_spin in range(2):
-            for i_orb, evl in enumerate(self.evals[i_spin]):
-                if np.abs(energy - evl) <= 3.0 * broadening:
-                    broad_coef = utils.gaussian(energy - evl, broadening)
-                    evec = self.evecs[i_spin][i_orb]
-                    orb_ldos_map = np.abs(self.calc_orb_map(evec, h, edge_space, dx, z_eff))**2
-                    final_map += broad_coef * orb_ldos_map
-        return final_map
-
-    def plot_sts_map(self,
-                     ax,
-                     energy,
-                     broadening=0.05,
-                     h=10.0,
-                     edge_space=5.0,
-                     dx=0.1,
-                     title=None,
-                     cmap='seismic',
-                     z_eff=3.25):
-
-        final_map = self.calc_sts_map(energy, broadening, h, edge_space, dx, z_eff)
-
-        extent = self._get_atoms_extent(self.ase_geom, edge_space)
-
-        ax.imshow(final_map.T, origin='lower', cmap=cmap, extent=extent)
-        ax.axis('off')
-        ax.set_title(title)
-
-    def plot_eigenvector(self, ax, evec, title=None):
-        utils.make_evec_plot(ax, self.ase_geom, self.neighbor_list, evec, title=title)
-
-    def plot_mo_eigenvector(self, mo_index, spin=0, ax=None):
-        title = "mo%d s%d %s, en: %.2f" % (mo_index, spin, utils.orb_label(
-            mo_index, self.num_spin_el[spin]), self.evals[spin][mo_index])
-        if ax is None:
-            plt.figure(figsize=self.figure_size)
-            self.plot_eigenvector(plt.gca(), self.evecs[spin][mo_index], title=title)
-            plt.show()
-        else:
-            self.plot_eigenvector(ax, self.evecs[spin][mo_index], title=title)
-
-    def plot_no_eigenvector(self, no_index, ax=None):
-        title = "no%d, occ=%.4f" % (no_index, self.no_evals[no_index])
-        if ax is None:
-            plt.figure(figsize=self.figure_size)
-            self.plot_eigenvector(plt.gca(), self.no_evecs[no_index], title=title)
-            plt.show()
-        else:
-            self.plot_eigenvector(ax, self.no_evecs[no_index], title=title)
-
-    def report(self, num_orb=2, sts_h=10.0, sts_broad=0.05):
-
-        print(f"multiplicity:       {self.multiplicity:12d}")
-        print(f"abs. magnetization: {self.abs_mag:12.4f}")
-        print(f"energy:             {self.energy: 12.4f}")
-        print("---")
-        print("spin density:")
-        plt.figure(figsize=self.figure_size)
-        utils.make_evec_plot(plt.gca(), self.ase_geom, self.neighbor_list, self.spin_density)
-        plt.show()
-
-        print("---")
-        print("eigenvalues:")
-        self.plot_evals(self.evals)
-
-        gap_a, gap_b, gap = self.gaps(self.evals)
-        print(f"gap alpha: {gap_a:.4f}")
-        print(f"gap beta:  {gap_b:.4f}")
-        print(f"gap eff.:  {gap:.4f}")
-
-        print("---")
-        print("frontier orbitals:")
-
-        for i_rel in np.arange(num_orb, -num_orb, -1):
-
-            i_mo = int(np.around(0.5 * (self.num_spin_el[0] + self.num_spin_el[1]))) + i_rel - 1
-
-            if i_mo < 0 or i_mo > len(self.evecs[0]) - 1:
-                continue
-
-            _fig, axs = plt.subplots(nrows=1, ncols=4, figsize=(4 * self.figure_size[0], self.figure_size[1]))
-
-            self.plot_mo_eigenvector(i_mo, spin=0, ax=axs[0])
-            self.plot_mo_eigenvector(i_mo, spin=1, ax=axs[1])
-
-            title1 = "sts h=%.1f, en: %.2f" % (sts_h, self.evals[0][i_mo])
-            self.plot_sts_map(axs[2], self.evals[0][i_mo], broadening=sts_broad, h=sts_h, title=title1)
-
-            title2 = "sts h=%.1f, en: %.2f" % (sts_h, self.evals[1][i_mo])
-            self.plot_sts_map(axs[3], self.evals[1][i_mo], broadening=sts_broad, h=sts_h, title=title2)
-
-            plt.show()
-
-    def calculate_natural_orbitals(self):
-        # build the one particle reduced density matrix
-        dens_mat = None
-
-        for i_spin in range(2):
-            for i_el in range(self.num_spin_el[i_spin]):
-                evec = self.evecs[i_spin, i_el]
-                if dens_mat is None:
-                    dens_mat = np.outer(evec, np.conj(evec))
-                else:
-                    dens_mat += np.outer(evec, np.conj(evec))
-
-        # Diagonalize the density matrix
-        self.no_evals, self.no_evecs = np.linalg.eig(dens_mat)
-        self.no_evals = np.abs(self.no_evals)
-        self.no_evecs = self.no_evecs.T
-
-        # sort the natural orbitals based on occupations
-        sort_inds = (-1 * self.no_evals).argsort()
-        self.no_evals = self.no_evals[sort_inds]
-        self.no_evecs = self.no_evecs[sort_inds]

--- a/tb_mean_field_hubbard/mfh.py
+++ b/tb_mean_field_hubbard/mfh.py
@@ -136,6 +136,13 @@ class MeanFieldHubbardModel:
                 print("Error: please specify (atom index 1, atom index 2, hopping)")
                 return
             i1, i2, t = custom_t
+            if i1 == i2:
+                print("Error: can't specify hopping from a site to itself.")
+                return
+            if not (0 <= i1 < self.num_atoms) or not (0 <= i2 < self.num_atoms):
+                print("Error: index out of range.")
+                return
+            if i1 < i2: i1, i2 = i2, i1
             self.model_a.set_hop(-t, i1, i2, mode='reset')
             self.model_b.set_hop(-t, i1, i2, mode='reset')
 

--- a/tb_mean_field_hubbard/mfh_pp.py
+++ b/tb_mean_field_hubbard/mfh_pp.py
@@ -1,0 +1,204 @@
+import numpy as np
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+
+from . import utils
+
+
+class MFHPostProcess:
+    """
+    Runs various post-processing and visualization on a converged MeanFieldHubbardModel
+    """
+    def __init__(self, mfh_model):
+
+        self.mfh = mfh_model
+
+        # natural orbital evals and evecs
+        self.no_evals = None
+        self.no_evecs = None
+
+    def plot_evals(self, evals, filename=None):
+        plt.figure(figsize=(3.0, 6))
+        ax = plt.gca()
+
+        for i_spin in range(2):
+            for i_ev, ev in enumerate(evals[i_spin]):
+                col = 'blue'
+                if i_ev < self.mfh.num_spin_el[i_spin]:
+                    col = 'red'
+                line_pos = [0.1, 0.9] if i_spin == 0 else [1.1, 1.9]
+                plt.plot(line_pos, [ev, ev], '-', color=col, lw=2.0, solid_capstyle='round')
+
+        blue_patch = mpatches.Patch(color='blue', label='empty')
+        red_patch = mpatches.Patch(color='red', label='occupied')
+        plt.legend(handles=[blue_patch, red_patch], loc='upper left', bbox_to_anchor=(1.0, 1.0))
+
+        #ax.get_xaxis().set_visible(False)
+        ax.spines['right'].set_visible(False)
+        ax.spines['top'].set_visible(False)
+        #ax.spines['bottom'].set_visible(False)
+        plt.xlim(0.0, 2.0)
+        plt.xticks([0.5, 1.5], ["spin α", "spin β"])
+        #plt.ylim(-6.0, 10.0)
+        plt.ylabel("Energy (eV)")
+        #plt.yticks(fontsize=30)
+        if filename is not None:
+            plt.savefig(filename, dpi=300, bbox_inches='tight')
+        plt.show()
+
+    def _get_atoms_extent(self, atoms, edge_space):
+        xmin = np.min(atoms.positions[:, 0]) - edge_space
+        xmax = np.max(atoms.positions[:, 0]) + edge_space
+        ymin = np.min(atoms.positions[:, 1]) - edge_space
+        ymax = np.max(atoms.positions[:, 1]) + edge_space
+        return [xmin, xmax, ymin, ymax]
+
+    def calc_orb_map(self, evec, h=10.0, edge_space=5.0, dx=0.1, z_eff=3.25):
+
+        extent = self._get_atoms_extent(self.mfh.ase_geom, edge_space)
+
+        # define grid
+        x_arr = np.arange(extent[0], extent[1], dx)
+        y_arr = np.arange(extent[2], extent[3], dx)
+
+        # update extent so that it matches with grid size
+        extent[1] = x_arr[-1] + dx
+        extent[3] = y_arr[-1] + dx
+
+        orb_map = np.zeros((len(x_arr), len(y_arr)), dtype=np.complex)
+
+        for at, coef in zip(self.mfh.ase_geom, evec):
+            p = at.position
+            local_i, local_grid = utils.get_local_grid(x_arr, y_arr, p, cutoff=1.2 * h + 4.0)
+            pz_orb = utils.carbon_2pz_slater(local_grid[0] - p[0], local_grid[1] - p[1], h, z_eff)
+            orb_map[local_i[0]:local_i[1], local_i[2]:local_i[3]] += coef * pz_orb
+
+        return orb_map, extent
+
+    def plot_orb_squared_map(self, ax, evec, h=10.0, edge_space=5.0, dx=0.1, title=None, cmap='seismic', z_eff=3.25):
+        orb_map, extent = self.calc_orb_map(evec, h, edge_space, dx, z_eff)
+        ax.imshow((np.abs(orb_map)**2).T, origin='lower', cmap=cmap, extent=extent)
+        ax.axis('off')
+        ax.set_title(title)
+
+    def calc_sts_map(self, energy, broadening=0.05, h=10.0, edge_space=5.0, dx=0.1, z_eff=3.25):
+
+        final_map = None
+        extent = None
+
+        for i_spin in range(2):
+            for i_orb, evl in enumerate(self.mfh.evals[i_spin]):
+                if np.abs(energy - evl) <= 3.0 * broadening:
+                    broad_coef = utils.gaussian(energy - evl, broadening)
+                    evec = self.mfh.evecs[i_spin][i_orb]
+                    orb_map, extent = self.calc_orb_map(evec, h, edge_space, dx, z_eff)
+                    if final_map is None:
+                        final_map = broad_coef * np.abs(orb_map)**2
+                    else:
+                        final_map += broad_coef * np.abs(orb_map)**2
+
+        return final_map, extent
+
+    def plot_sts_map(self,
+                     ax,
+                     energy,
+                     broadening=0.05,
+                     h=10.0,
+                     edge_space=5.0,
+                     dx=0.1,
+                     title=None,
+                     cmap='seismic',
+                     z_eff=3.25):
+
+        final_map, extent = self.calc_sts_map(energy, broadening, h, edge_space, dx, z_eff)
+
+        ax.imshow(final_map.T, origin='lower', cmap=cmap, extent=extent)
+        ax.axis('off')
+        ax.set_title(title)
+
+    def plot_eigenvector(self, ax, evec, title=None):
+        utils.make_evec_plot(ax, self.mfh.ase_geom, self.mfh.neighbor_list, evec, title=title)
+
+    def plot_mo_eigenvector(self, mo_index, spin=0, ax=None):
+        title = "mo%d s%d %s, en: %.2f" % (mo_index, spin, utils.orb_label(
+            mo_index, self.mfh.num_spin_el[spin]), self.mfh.evals[spin][mo_index])
+        if ax is None:
+            plt.figure(figsize=self.mfh.figure_size)
+            self.plot_eigenvector(plt.gca(), self.mfh.evecs[spin][mo_index], title=title)
+            plt.show()
+        else:
+            self.plot_eigenvector(ax, self.mfh.evecs[spin][mo_index], title=title)
+
+    def plot_no_eigenvector(self, no_index, ax=None):
+        title = "no%d, occ=%.4f" % (no_index, self.no_evals[no_index])
+        if ax is None:
+            plt.figure(figsize=self.mfh.figure_size)
+            self.plot_eigenvector(plt.gca(), self.no_evecs[no_index], title=title)
+            plt.show()
+        else:
+            self.plot_eigenvector(ax, self.no_evecs[no_index], title=title)
+
+    def report(self, num_orb=2, sts_h=10.0, sts_broad=0.05):
+
+        print(f"multiplicity:       {self.mfh.multiplicity:12d}")
+        print(f"abs. magnetization: {self.mfh.abs_mag:12.4f}")
+        print(f"energy:             {self.mfh.energy: 12.4f}")
+        print("---")
+        print("spin density:")
+        plt.figure(figsize=self.mfh.figure_size)
+        utils.make_evec_plot(plt.gca(), self.mfh.ase_geom, self.mfh.neighbor_list, self.mfh.spin_density)
+        plt.show()
+
+        print("---")
+        print("eigenvalues:")
+        self.plot_evals(self.mfh.evals)
+
+        print(f"gap alpha: {self.mfh.gap_a:.4f}")
+        print(f"gap beta:  {self.mfh.gap_b:.4f}")
+        print(f"gap eff.:  {self.mfh.gap_eff:.4f}")
+
+        print("---")
+        print("frontier orbitals:")
+
+        for i_rel in np.arange(num_orb, -num_orb, -1):
+
+            i_mo = int(np.around(0.5 * (self.mfh.num_spin_el[0] + self.mfh.num_spin_el[1]))) + i_rel - 1
+
+            if i_mo < 0 or i_mo > len(self.mfh.evecs[0]) - 1:
+                continue
+
+            _fig, axs = plt.subplots(nrows=1, ncols=4, figsize=(4 * self.mfh.figure_size[0], self.mfh.figure_size[1]))
+
+            self.plot_mo_eigenvector(i_mo, spin=0, ax=axs[0])
+            self.plot_mo_eigenvector(i_mo, spin=1, ax=axs[1])
+
+            title1 = "sts h=%.1f, en: %.2f" % (sts_h, self.mfh.evals[0][i_mo])
+            self.plot_sts_map(axs[2], self.mfh.evals[0][i_mo], broadening=sts_broad, h=sts_h, title=title1)
+
+            title2 = "sts h=%.1f, en: %.2f" % (sts_h, self.mfh.evals[1][i_mo])
+            self.plot_sts_map(axs[3], self.mfh.evals[1][i_mo], broadening=sts_broad, h=sts_h, title=title2)
+
+            plt.show()
+
+    def calculate_natural_orbitals(self):
+        # build the one particle reduced density matrix
+        dens_mat = None
+
+        for i_spin in range(2):
+            for i_el in range(self.mfh.num_spin_el[i_spin]):
+                evec = self.mfh.evecs[i_spin, i_el]
+                if dens_mat is None:
+                    dens_mat = np.outer(evec, np.conj(evec))
+                else:
+                    dens_mat += np.outer(evec, np.conj(evec))
+
+        # Diagonalize the density matrix
+        self.no_evals, self.no_evecs = np.linalg.eig(dens_mat)
+        self.no_evals = np.abs(self.no_evals)
+        self.no_evecs = self.no_evecs.T
+
+        # sort the natural orbitals based on occupations
+        sort_inds = (-1 * self.no_evals).argsort()
+        self.no_evals = self.no_evals[sort_inds]
+        self.no_evecs = self.no_evecs[sort_inds]

--- a/tb_mean_field_hubbard/utils.py
+++ b/tb_mean_field_hubbard/utils.py
@@ -3,10 +3,22 @@ import scipy.special
 
 import matplotlib.pyplot as plt
 
+import igor_tools
+
+### ------------------------------------------------------------------------------
+### PUBLIC TOOLS
+### ------------------------------------------------------------------------------
+
+def create_itx(data, extent, wavename, filename):
+    dx = (extent[1] - extent[0]) / data.shape[0]
+    dy = (extent[3] - extent[2]) / data.shape[1]
+    xaxis = (extent[0], dx, "[ang]")
+    yaxis = (extent[2], dy, "[ang]")
+    igor_tools.write_2d_itx(filename, data, xaxis, yaxis, wavename)
+
 ### ------------------------------------------------------------------------------
 ### GEOMETRY TOOLS
 ### ------------------------------------------------------------------------------
-
 
 def scale_atoms(atoms, factor):
     cell_defined = True


### PR DESCRIPTION
* Backwards compatibility broken by migrating all post-processing routines to `MeanFieldHubbardModel.pp`. Methods and usage remains the same, but `pp` needs to be added in many cases, e.g. `mfh_model.pp.calculate_sts_map()`
* Possibility to export calculated 2d data maps in `itx` format